### PR TITLE
PowerSplitDevice motor flange

### DIFF
--- a/VehicleInterfaces/Transmissions.mo
+++ b/VehicleInterfaces/Transmissions.mo
@@ -431,10 +431,6 @@ gear number is ignored in this model.</p>
 
     parameter Real ratio=100/50
       "Number of ring_teeth/sun_teeth (e.g. ratio=100/50)";
-    Modelica.Mechanics.MultiBody.Interfaces.FlangeWithBearing motorFlange(
-        final includeBearingConnector=includeTransmissionBearing or
-          usingMultiBodyEngine) "Connection to the engine"
-      annotation (Placement(transformation(extent={{-110,-70},{-90,-50}})));
     Modelica.Mechanics.Rotational.Sensors.SpeedSensor outputSpeed
       annotation (Placement(transformation(
           origin={60,60},

--- a/VehicleInterfaces/Transmissions.mo
+++ b/VehicleInterfaces/Transmissions.mo
@@ -165,14 +165,14 @@ See the <a href=\"modelica://VehicleInterfaces.Transmissions\">documentation</a>
         annotation (Dialog(tab="Advanced"));
 
       Mechanics.MultiBody.MultiBodyEnd end_3(final includeBearingConnector=
-            includeTransmissionBearing or usingMultiBodyEngine)
+            includeTransmissionBearing or usingMultiBodyMotor)
         annotation (Placement(transformation(
             origin={-100,-82},
             extent={{-8,-6},{8,6}},
             rotation=90)));
       Modelica.Mechanics.MultiBody.Interfaces.FlangeWithBearing motorFlange(
           final includeBearingConnector=includeTransmissionBearing or
-            usingMultiBodyEngine) "Connection to the engine"
+            usingMultiBodyMotor) "Connection to the motor"
         annotation (Placement(transformation(extent={{-110,-70},{-90,-50}})));
     protected
       parameter Boolean includeMotorBearing=false

--- a/VehicleInterfaces/Transmissions.mo
+++ b/VehicleInterfaces/Transmissions.mo
@@ -165,13 +165,13 @@ See the <a href=\"modelica://VehicleInterfaces.Transmissions\">documentation</a>
         annotation (Dialog(tab="Advanced"));
 
       Mechanics.MultiBody.MultiBodyEnd end_3(final includeBearingConnector=
-            includeTransmissionBearing or usingMultiBodyMotor)
+            includeMotorBearing or usingMultiBodyMotor)
         annotation (Placement(transformation(
             origin={-100,-82},
             extent={{-8,-6},{8,6}},
             rotation=90)));
       Modelica.Mechanics.MultiBody.Interfaces.FlangeWithBearing motorFlange(
-          final includeBearingConnector=includeTransmissionBearing or
+          final includeBearingConnector=includeMotorBearing or
             usingMultiBodyMotor) "Connection to the motor"
         annotation (Placement(transformation(extent={{-110,-70},{-90,-50}})));
     protected


### PR DESCRIPTION
This fixes two issues with the PowerSplitDevice.

1. The motorFlange was declared both in PowerSplitDevice and in its base class BaseTwoInputTransmission. The redundant declaration is removed.
1. The motorFlange conditional bearing frame was previously set by the flag usingMultiBodyEngine instead of usingMultiBodyMotor. This is corrected.