### PR TITLE
Add license files

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,31 @@
+Copyright (C) 2005-2013, Dassault Systémes, DLR and Modelon
+Copyright (C) 2013-2021, Modelica Association
+All rights reserved.
+
+The VehicleInterfaces library is distributed under the Modelica License (Version 1.1).
+
+Redistribution and use in source and binary forms, with or without
+modification are permitted, provided that the following conditions are met:
+* The author and copyright notices in the source files, these license
+  conditions and the disclaimer below are (a) retained and (b) reproduced in
+  the documentation provided with the distribution.
+* Modifications of the original source files are allowed, provided that a
+  prominent notice is inserted in each changed file and the accompanying
+  documentation, stating how and when the file was modified, and provided
+  that the conditions under (1) are met.
+* It is not allowed to charge a fee for the original version or a modified
+  version of the software, besides a reasonable fee for distribution and
+  support. Distribution in aggregate with other (possibly commercial)
+  programs as part of a larger (possibly commercial) software distribution
+  is permitted, provided that it is not advertised as a product of your own.
+
+Disclaimer
+The software (sources, binaries, etc.) in their original or in a modified
+form are provided "as is" and the copyright holders assume no responsibility
+for its contents what so ever. Any express or implied warranties, including,
+but not limited to, the implied warranties of merchantability and fitness
+for a particular purpose are disclaimed. In no event shall the copyright
+holders, or any party who modify and/or redistribute the package, be liable
+for any direct, indirect, incidental, special, exemplary, or consequential
+damages, arising in any way out of the use of this software, even if
+advised of the possibility of such damage.

--- a/README.md
+++ b/README.md
@@ -21,9 +21,8 @@ Download [VehicleInterfaces v2.0.0 (2020-06-26)](../../releases/tag/v2.0.0)
 Browse the [Releases](../../releases) page in order to get access to older releases of the library.
 
 ## License
-Copyright &copy; 2005-2013, Dassault Syst&egrave;mes, DLR and Modelon
-
-Copyright &copy; 2013- Modelica Association
+Copyright &copy; 2005-2013, Dassault Systémes, DLR and Modelon
+Copyright &copy; 2013-2021, Modelica Association
 
 This Modelica package is free software and the use is completely at your own risk;
 it can be redistributed and/or modified under the terms of the [Modelica License 1.1](https://modelica.org/licenses/ModelicaLicense1.1).

--- a/VehicleInterfaces/Resources/Licenses/LICENSE_VehicleInterfaces.txt
+++ b/VehicleInterfaces/Resources/Licenses/LICENSE_VehicleInterfaces.txt
@@ -1,0 +1,31 @@
+Copyright (C) 2005-2013, Dassault Systémes, DLR and Modelon
+Copyright (C) 2013-2021, Modelica Association
+All rights reserved.
+
+The VehicleInterfaces library is distributed under the Modelica License (Version 1.1).
+
+Redistribution and use in source and binary forms, with or without
+modification are permitted, provided that the following conditions are met:
+* The author and copyright notices in the source files, these license
+  conditions and the disclaimer below are (a) retained and (b) reproduced in
+  the documentation provided with the distribution.
+* Modifications of the original source files are allowed, provided that a
+  prominent notice is inserted in each changed file and the accompanying
+  documentation, stating how and when the file was modified, and provided
+  that the conditions under (1) are met.
+* It is not allowed to charge a fee for the original version or a modified
+  version of the software, besides a reasonable fee for distribution and
+  support. Distribution in aggregate with other (possibly commercial)
+  programs as part of a larger (possibly commercial) software distribution
+  is permitted, provided that it is not advertised as a product of your own.
+
+Disclaimer
+The software (sources, binaries, etc.) in their original or in a modified
+form are provided "as is" and the copyright holders assume no responsibility
+for its contents what so ever. Any express or implied warranties, including,
+but not limited to, the implied warranties of merchantability and fitness
+for a particular purpose are disclaimed. In no event shall the copyright
+holders, or any party who modify and/or redistribute the package, be liable
+for any direct, indirect, incidental, special, exemplary, or consequential
+damages, arising in any way out of the use of this software, even if
+advised of the possibility of such damage.

--- a/VehicleInterfaces/UsersGuide.mo
+++ b/VehicleInterfaces/UsersGuide.mo
@@ -1080,10 +1080,10 @@ on the library.
 <h4>Copyright</h4>
 <p>
 &copy; 2005-2013: Dassault Syst&egrave;mes, DLR and Modelon<br>
-&copy; since 2013: Modelica Association
+&copy; 2013-2021: Modelica Association
 </p>
 <h4>License</h4>
-<p>The VehicleInterfaces library is distributed under the Modelica license (Version 1.1)</p>
+<p>The VehicleInterfaces library is distributed under the Modelica License (Version 1.1).</p>
 <p>Redistribution and use in source and binary forms, with or without
 modification are permitted, provided that the following conditions are met:
 </p>


### PR DESCRIPTION
This PR adds the license file of the own work to

* the repository root for more transparency.
* the Reosurces/Licenses directory in preparation of MCP-0029 to better support tool vendors when distributing (derived work of) the VehicleInterfaces.

The license text was copied from [ModelicaLicense 1.1](https://modelica.org/licenses/ModelicaLicense1.1/ModelicaLicense1.1.txt/view.html).

See also https://github.com/modelica-3rdparty/Modelica_DeviceDrivers/pull/313