### PR TITLE
Delete VehicleInterfaces/libraryinfo.mos

### DIFF
--- a/VehicleInterfaces/libraryinfo.mos
+++ b/VehicleInterfaces/libraryinfo.mos
@@ -1,9 +1,0 @@
-LibraryInfoMenuCommand(
-category = "libraries",
-text = "VehicleInterfaces",
-reference = "VehicleInterfaces",
-version = "2.0.2",
-isModel = true,
-description = "VehicleInterfaces Library (version 2.0.2)",
-ModelicaVersion = "4.1.0",
-pos = 103);


### PR DESCRIPTION
This is a Dymola-specific file that we can manage as part of the Dymola distribution, there is no need to pollute the MA GitHub repository.